### PR TITLE
feat: add reset command

### DIFF
--- a/src/commands/_CommandList.ts
+++ b/src/commands/_CommandList.ts
@@ -2,6 +2,7 @@ import { CommandInt } from "../interfaces/CommandInt";
 import { edit } from "./edit";
 import { help } from "./help";
 import { oneHundred } from "./oneHundred";
+import { reset } from "./reset";
 import { view } from "./view";
 
-export const CommandList: CommandInt[] = [oneHundred, view, help, edit];
+export const CommandList: CommandInt[] = [oneHundred, view, help, edit, reset];

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -1,0 +1,63 @@
+import { SlashCommandBuilder } from "@discordjs/builders";
+import { Message, MessageActionRow, MessageButton } from "discord.js";
+import { CommandInt } from "../interfaces/CommandInt";
+import { getCamperData } from "../modules/getCamperData";
+import { errorHandler } from "../utils/errorHandler";
+
+export const reset: CommandInt = {
+  data: new SlashCommandBuilder()
+    .setName("reset")
+    .setDescription("Reset your 100 Days of Code progress."),
+  run: async (interaction) => {
+    try {
+      await interaction.deferReply();
+      const { user } = interaction;
+      const confirmButton = new MessageButton()
+        .setCustomId("confirm")
+        .setLabel("Confirm")
+        .setEmoji("✅")
+        .setStyle("PRIMARY");
+      const row = new MessageActionRow().addComponents([confirmButton]);
+      const response = (await interaction.editReply({
+        content:
+          "This will delete all of your stored 100 Days of Code progress. You will start at Round 1 Day 1. If you are sure this is what you want to do, click the button below.",
+        components: [row],
+      })) as Message;
+
+      const collector = response.createMessageComponentCollector({
+        time: 30000,
+        filter: (click) => click.user.id === user.id,
+        max: 1,
+      });
+
+      collector.on("collect", async (click) => {
+        await click.deferUpdate();
+        const camperData = await getCamperData(user.id);
+
+        if (!camperData) {
+          await interaction.editReply({
+            content: "There was an error fetching your data.",
+          });
+          return;
+        }
+
+        await camperData.delete();
+
+        await interaction.editReply({
+          content: "Your 100 Days of Code progress has been reset.",
+        });
+        return;
+      });
+
+      collector.on("end", async () => {
+        const disabledButton = confirmButton.setDisabled(true);
+        const row = new MessageActionRow().addComponents([disabledButton]);
+        await interaction.editReply({
+          components: [row],
+        });
+      });
+    } catch (err) {
+      errorHandler("reset command", err);
+    }
+  },
+};


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Folks were asking for a way to reset their progress. This adds a command to do so.